### PR TITLE
GitHub api more data

### DIFF
--- a/lib/domain/entities/git_repository_data.dart
+++ b/lib/domain/entities/git_repository_data.dart
@@ -5,6 +5,7 @@ import 'package:flutter_engineer_codecheck/domain/value_objects/count_watcher.da
 import 'package:flutter_engineer_codecheck/domain/value_objects/owner_icon_url.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/project_language.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_description.dart';
+import 'package:flutter_engineer_codecheck/domain/value_objects/repository_id.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_name.dart';
 
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -16,6 +17,9 @@ part 'git_repository_data.g.dart';
 class GitRepositoryData with _$GitRepositoryData {
   const GitRepositoryData._(); //メソッド不要の場合、削除
   const factory GitRepositoryData({
+    /// 該当リポジトリのリポジトリID
+    @RepositoryIdConverter() required RepositoryId repositoryId,
+
     /// 該当リポジトリのリポジトリ名
     @RepositoryNameConverter() required RepositoryName repositoryName,
 

--- a/lib/domain/repositories/git_repository.dart
+++ b/lib/domain/repositories/git_repository.dart
@@ -4,5 +4,9 @@ import '../entities/git_repository_data.dart';
 /// Githubだけではなく、他のGitでデータ取得をするケースも想定して、抽象クラスを作成する。
 abstract class GitRepository {
   /// キーワードに対する検索結果を取得する
-  Future<List<GitRepositoryData>> search(String keyword);
+  /// [page]で何ページ目かを指定する。Githubでは、最初のページは1ページ目。
+  Future<List<GitRepositoryData>> search(
+    String keyword, {
+    int page = 1,
+  });
 }

--- a/lib/domain/repositories/git_repository.dart
+++ b/lib/domain/repositories/git_repository.dart
@@ -9,4 +9,7 @@ abstract class GitRepository {
     String keyword, {
     int page = 1,
   });
+
+  /// 最初の1ページ目のインデックス
+  int getFirstPageIndex();
 }

--- a/lib/domain/value_objects/repository_id.dart
+++ b/lib/domain/value_objects/repository_id.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_engineer_codecheck/domain/value_objects/value_object.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// 該当リポジトリのIDを表すValueObject
+class RepositoryId extends ValueObject<int> {
+  RepositoryId(super.value);
+}
+
+class RepositoryIdConverter implements JsonConverter<RepositoryId, String> {
+  const RepositoryIdConverter();
+
+  @override
+  RepositoryId fromJson(String jsonData) {
+    return RepositoryId(int.parse(jsonData));
+  }
+
+  @override
+  String toJson(RepositoryId object) {
+    return object.toString();
+  }
+}

--- a/lib/infrastructures/github_repositories/dto/item.dart
+++ b/lib/infrastructures/github_repositories/dto/item.dart
@@ -11,6 +11,7 @@ import 'package:flutter_engineer_codecheck/domain/value_objects/count_watcher.da
 import 'package:flutter_engineer_codecheck/domain/value_objects/owner_icon_url.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/project_language.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_name.dart';
+import 'package:flutter_engineer_codecheck/domain/value_objects/repository_id.dart';
 import 'owner.dart';
 
 part 'item.freezed.dart';
@@ -26,6 +27,9 @@ class Item with _$Item {
     fieldRename: FieldRename.snake,
   )
   const factory Item({
+    /// レポジトリID
+    required int id,
+
     /// レポジトリ名
     required String name,
 
@@ -55,6 +59,7 @@ class Item with _$Item {
 
   GitRepositoryData toGitRepositoryData() {
     return GitRepositoryData(
+      repositoryId: RepositoryId(id),
       repositoryName: RepositoryName(name),
       ownerIconUrl: OwnerIconUrl(owner.avatarUrl),
       projectLanguage: ProjectLanguage(language),

--- a/lib/infrastructures/github_repositories/github_repository.dart
+++ b/lib/infrastructures/github_repositories/github_repository.dart
@@ -40,4 +40,9 @@ class GithubRepository implements GitRepository {
     final result = Result.fromJson(map);
     return result.items.map((item) => item.toGitRepositoryData());
   }
+
+  @override
+  int getFirstPageIndex() {
+    return 1;
+  }
 }

--- a/lib/infrastructures/github_repositories/github_repository.dart
+++ b/lib/infrastructures/github_repositories/github_repository.dart
@@ -11,13 +11,26 @@ import 'dto/result.dart';
 /// ・ネットワークが繋がっていない、または遅い
 /// ・WebAPIの形式が変更された
 class GithubRepository implements GitRepository {
+  /// パラメータのキーワードの置換用文字列
+  static const kParamKeyword = '<keyword>';
+
+  /// パラメータのページ数の置換用文字列
+  static const kParamPage = '<page>';
+
+  /// Github APIへアクセスするためのURL
   static const String apiUrl =
-      'https://api.github.com/search/repositories?q=<keyword>';
+      'https://api.github.com/search/repositories?q=$kParamKeyword&page=$kParamPage';
 
   @override
-  Future<List<GitRepositoryData>> search(String keyword) async {
+  Future<List<GitRepositoryData>> search(
+    String keyword, {
+    int page = 1,
+  }) async {
     // TODO 並び順、ページ数などへの対応
-    final apiUri = Uri.parse(apiUrl.replaceFirst('<keyword>', keyword));
+    final uri = apiUrl
+        .replaceFirst(kParamKeyword, keyword)
+        .replaceFirst(kParamPage, page.toString());
+    final apiUri = Uri.parse(uri);
     http.Response response = await http.get(apiUri);
     return fromJson(response.body).toList();
   }

--- a/lib/ui/pages/search_result_page/search_result-notifier.dart
+++ b/lib/ui/pages/search_result_page/search_result-notifier.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_engineer_codecheck/domain/entities/git_repository_data.dart';
+import 'package:flutter_engineer_codecheck/domain/repositories/git_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// 検索結果を表示するためのStateNotifier
+/// (参考) https://www.zeroichi.biz/blog/1525/
+class SearchResultNotifier
+    extends StateNotifier<AsyncValue<List<GitRepositoryData>>> {
+  SearchResultNotifier(this.repository)
+      : super(const AsyncLoading<List<GitRepositoryData>>()) {}
+
+  final GitRepository repository;
+
+  /// データの読込
+  Future<void> fetch(String keyword, int page, bool isLoadMore) async {
+    state = await AsyncValue.guard(() async {
+      final newData = await repository.search(keyword, page: page);
+      // return [if (isLoadMore) ...state.value ?? [], ...newData];
+      return newData;
+    });
+  }
+
+  void load(String keyword, int page, isLoadMoreData) {
+    // ローディング中にローディングしないようにする
+    if (state ==
+        const AsyncLoading<List<GitRepositoryData>>().copyWithPrevious(state)) {
+      return;
+    }
+
+    // 取得済みのデータを保持しながら状態をローディング中にする
+    state =
+        const AsyncLoading<List<GitRepositoryData>>().copyWithPrevious(state);
+
+    fetch(keyword, page, isLoadMoreData);
+  }
+}

--- a/lib/ui/pages/search_result_page/search_result_page.dart
+++ b/lib/ui/pages/search_result_page/search_result_page.dart
@@ -41,9 +41,18 @@ class _SearchResultPageState extends ConsumerState<SearchResultPage> {
             child: _vm.getRepositoryData.when(
           error: (error, _) => Text(error.toString()),
           loading: () => LoadingRotating.square(),
-          data: (data) => SearchResultListView(
-            data: data,
-            onTapped: _vm.onRepositoryTapped,
+          data: (data) => NotificationListener<ScrollEndNotification>(
+            onNotification: (ScrollEndNotification notification) {
+              bool isReachScrollEnd = notification.metrics.extentAfter == 0;
+              if (isReachScrollEnd) {
+                _vm.onLoadMore();
+              }
+              return isReachScrollEnd;
+            },
+            child: SearchResultListView(
+              data: data,
+              onTapped: _vm.onRepositoryTapped,
+            ),
           ),
         )),
       ],

--- a/lib/ui/pages/search_result_page/search_result_page.dart
+++ b/lib/ui/pages/search_result_page/search_result_page.dart
@@ -29,6 +29,7 @@ class _SearchResultPageState extends ConsumerState<SearchResultPage> {
   void initState() {
     super.initState();
     _vm.setRef(ref);
+    _vm.onLoad(widget.keyword);
   }
 
   @override
@@ -37,14 +38,14 @@ class _SearchResultPageState extends ConsumerState<SearchResultPage> {
       title: '[${widget.keyword}]の検索',
       children: [
         Expanded(
-            child: _vm.getRepositoryData(widget.keyword).when(
-                  error: (error, _) => Text(error.toString()),
-                  loading: () => LoadingRotating.square(),
-                  data: (data) => SearchResultListView(
-                    data: data,
-                    onTapped: _vm.onRepositoryTapped,
-                  ),
-                )),
+            child: _vm.getRepositoryData.when(
+          error: (error, _) => Text(error.toString()),
+          loading: () => LoadingRotating.square(),
+          data: (data) => SearchResultListView(
+            data: data,
+            onTapped: _vm.onRepositoryTapped,
+          ),
+        )),
       ],
     );
   }

--- a/lib/ui/pages/search_result_page/search_result_page_vm.dart
+++ b/lib/ui/pages/search_result_page/search_result_page_vm.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_engineer_codecheck/domain/entities/git_repository_data.dart';
 import 'package:flutter_engineer_codecheck/ui/pages/repository_detail_page/repository_detail_page.dart';
+import 'package:flutter_engineer_codecheck/ui/pages/search_result_page/search_result-notifier.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -10,20 +11,35 @@ import '../../../domain/repositories/git_repository.dart';
 /// 剣客結果を表示するページのViewModel
 class SearchResultPageVm {
   // キーワードに基づいた検索結果を取得するProvider
-  final _repositoryData = FutureProvider.autoDispose
-      .family<List<GitRepositoryData>, String>((ref, keyword) async {
-    final result = GetIt.I.get<GitRepository>().search(keyword);
-    return result;
-  });
+  final _searchResultProvider = StateNotifierProvider<SearchResultNotifier,
+      AsyncValue<List<GitRepositoryData>>>(
+    (ref) => SearchResultNotifier(
+      GetIt.I.get<GitRepository>(),
+    ),
+  );
 
   // キーワードに基づいた検索結果を取得するProviderの状態を管理するAsyncValue
-  AsyncValue<List<GitRepositoryData>> getRepositoryData(String keyword) =>
-      _ref.watch(_repositoryData(keyword));
+  AsyncValue<List<GitRepositoryData>> get getRepositoryData =>
+      _ref.watch(_searchResultProvider);
 
   late final WidgetRef _ref;
   void setRef(WidgetRef ref) {
     _ref = ref;
   }
+
+  String _keyword = '';
+  int _page = 0;
+
+  void _fetch(String keyword, int page, bool isLoadMore) {
+    _ref.read(_searchResultProvider.notifier).fetch(keyword, page, isLoadMore);
+  }
+
+  void onLoad(String keyword) {
+    _keyword = keyword;
+    _fetch(_keyword, 1, false);
+  }
+
+  void onLoadMore() {}
 
   /// レポジトリのカードが押下されたら、レポジトリ詳細画面に遷移する
   void onRepositoryTapped(

--- a/test/domain/entities/git_repository_data.dart
+++ b/test/domain/entities/git_repository_data.dart
@@ -6,12 +6,14 @@ import 'package:flutter_engineer_codecheck/domain/value_objects/count_watcher.da
 import 'package:flutter_engineer_codecheck/domain/value_objects/owner_icon_url.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/project_language.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_description.dart';
+import 'package:flutter_engineer_codecheck/domain/value_objects/repository_id.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_name.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 main() {
   test('basic', () async {
     final target = GitRepositoryData(
+      repositoryId: RepositoryId(123),
       repositoryName: RepositoryName('repositoryName'),
       ownerIconUrl: OwnerIconUrl('OwnerIconUrl'),
       projectLanguage: ProjectLanguage('projectLanguage'),
@@ -22,6 +24,7 @@ main() {
       countIssue: CountIssue(4),
     );
 
+    expect(target.repositoryId(), 123);
     expect(target.repositoryName(), 'repositoryName');
     expect(target.ownerIconUrl(), 'OwnerIconUrl');
     expect(target.projectLanguage(), 'projectLanguage');

--- a/test/infrastructures/github_repositories/dto/item_test.dart
+++ b/test/infrastructures/github_repositories/dto/item_test.dart
@@ -143,6 +143,7 @@ main() async {
     final map = json.decode(jsonData);
     final result = Item.fromJson(map);
 
+    expect(result.id, 31792824);
     expect(result.name, 'flutter');
     expect(result.language, 'Dart');
     expect(result.stargazersCount, 146985);

--- a/test/infrastructures/github_repositories/github_repository_test.dart
+++ b/test/infrastructures/github_repositories/github_repository_test.dart
@@ -18,5 +18,19 @@ main() async {
     expect(result.first.repositoryName(), 'flutter');
   });
 
-  test('search', () async {});
+  test('page', () async {
+    final repository = GithubRepository();
+    final result = await repository.search('flutter');
+
+    expect(result.length, 30);
+    expect(result.first.repositoryName(), 'flutter');
+
+    // ページ1の最初は公式だし、多分「flutter」。
+    final page1 = await repository.search('flutter', page: 1);
+    expect(page1.first.repositoryName(), 'flutter');
+
+    // ページ2の最初は多分「Flutter」ではない
+    final page2 = await repository.search('flutter', page: 2);
+    expect(page2.first.repositoryName(), isNot('flutter'));
+  });
 }

--- a/test/ui/widgets/molecules/repository_data_card_test.dart
+++ b/test/ui/widgets/molecules/repository_data_card_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter_engineer_codecheck/domain/value_objects/count_watcher.da
 import 'package:flutter_engineer_codecheck/domain/value_objects/owner_icon_url.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/project_language.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_description.dart';
+import 'package:flutter_engineer_codecheck/domain/value_objects/repository_id.dart';
 import 'package:flutter_engineer_codecheck/domain/value_objects/repository_name.dart';
 import 'package:flutter_engineer_codecheck/ui/widgets/molecules/repository_data_card.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -17,6 +18,7 @@ Widget target() => MaterialApp(
         children: [
           RepositoryDataCard(
             data: GitRepositoryData(
+              repositoryId: RepositoryId(123),
               repositoryName: RepositoryName('repositoryName'),
               ownerIconUrl: OwnerIconUrl('OwnerIconUrl'),
               projectLanguage: ProjectLanguage('projectLanguage'),
@@ -30,6 +32,7 @@ Widget target() => MaterialApp(
           ),
           RepositoryDataCard(
             data: GitRepositoryData(
+              repositoryId: RepositoryId(31792824),
               repositoryName: RepositoryName('flutter'),
               ownerIconUrl: OwnerIconUrl('OwnerIconUrl1'),
               projectLanguage: ProjectLanguage('Dart'),


### PR DESCRIPTION
Github から2ページ以降のデータを取得・表示できるようにした
・GitRepositoryでページの指定をできるように修正した
・RiverpodのStateNofitierを使用して、新しいデータを表示する
https://www.zeroichi.biz/blog/1525/