### PR TITLE
ソート条件の選択画面のタイトルをenum自体に持たせ、全言語で統一することにした

### DIFF
--- a/lib/domain/repositories/git_repository.dart
+++ b/lib/domain/repositories/git_repository.dart
@@ -3,26 +3,30 @@ import '../entities/git_repository_data.dart';
 /// Gitの検索結果の表示順
 enum SortMethod {
   /// ベストマッチ順
-  bestMatch,
+  bestMatch('Best match'),
 
   /// スターが多い順
-  starDesc,
+  starDesc('Most stars'),
 
   /// スターが少ない順
-  starAsc,
+  starAsc('Fewest stars'),
 
   /// フォークが多い順
-  forkDesc,
+  forkDesc('Most forks'),
 
   /// フォークが少ない順
-  forkAsc,
+  forkAsc('Fewest forks'),
 
   /// 更新日時が新しい順
-  recentlyUpdated,
+  recentlyUpdated('Recently updated'),
 
   /// 更新日時が古い順
-  leastRecentlyUpdate;
+  leastRecentlyUpdate('Least recently updated');
 
+  const SortMethod(this.title);
+
+  /// 画面に表示するタイトル
+  final String title;
   String toJson() => toString();
 }
 

--- a/lib/ui/pages/search_page/search_page_vm.dart
+++ b/lib/ui/pages/search_page/search_page_vm.dart
@@ -5,6 +5,7 @@ import 'package:flutter_engineer_codecheck/ui/app_theme.dart';
 import 'package:flutter_engineer_codecheck/ui/pages/search_result_page/search_result_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
 /// 検索用のトップページのViewModel
 class SearchPageVm {
@@ -32,26 +33,18 @@ class SearchPageVm {
   Future<void> onSelectSortMethod(BuildContext context) async {
     final selectedSortMethod = await showConfirmationDialog<SortMethod>(
       context: context,
-      title: 'ソート方法',
-      message: 'ソートする方法を選択してください',
+      title: AppLocalizations.of(context).sortOptions,
       initialSelectedActionKey: _selectedSortMethod,
       actions:
-          // ソート方法から回答候補を作る
+          // ソート方法の一覧から回答候補一覧を作る
           SortMethod.values
               .map((method) => AlertDialogAction<SortMethod>(
-                  key: method, label: _getSortMethodTitle(method)))
+                  key: method, label: method.title))
               .toList(),
     );
 
     if (selectedSortMethod != null) {
       _selectedSortMethod = selectedSortMethod;
     }
-    print(selectedSortMethod);
-  }
-
-  /// ソート方法の表示を取得する
-  /// TODO 国際化対応できるようにしたい
-  String _getSortMethodTitle(SortMethod sortMethod) {
-    return sortMethod.toString();
   }
 }


### PR DESCRIPTION
(理由)
・enumから国際化対応の言語を取得するのが難しい
・文字列を翻訳しても、訳が怪しい