### PR TITLE
41 エラー画面を設定する

### DIFF
--- a/lib/domain/exceptions/git_repository_exception.dart
+++ b/lib/domain/exceptions/git_repository_exception.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+/// Gitシステムに通信時に発生するエラー
+/// ・ネットワークが繋がっていない
+/// ・URLを間違えている
+/// ・データが欠けている→TCP/IPを信じるので、ひとまず考えない
+class GitRepositoryException {
+  /// 未接続時の対応依頼メッセージ
+  static const _notConnectionMessage =
+      'Cannot connect to Github API. Check internet connection.'
+      'If you have no problem with the connection, please connect after a while';
+
+  /// リクエストに問題があったときの対応以来メッセージ
+  static const _incorrectFormat =
+      'Data not accepted due to incorrect data format.  Try again, and if not, contact the administrator.';
+
+  const GitRepositoryException({
+    this.exception,
+    required this.message,
+    this.stackTrace,
+  });
+
+  /// 基の例外
+  final Exception? exception;
+
+  /// ユーザへの対応メッセージ
+  final String message;
+
+  /// スタックトレース
+  final StackTrace? stackTrace;
+
+  /// 通信エラーによる例外(サーバに達しなかった場合)
+  const GitRepositoryException.NotConnected(SocketException exception,
+      {StackTrace? stackTrace})
+      : this(
+          exception: exception,
+          stackTrace: stackTrace,
+          message: _notConnectionMessage,
+        );
+
+  /// データフォーマットによる例外(サーバには達したが、無効なデータが返信された場合)
+  const GitRepositoryException.ValidationFailed(StackTrace stackTrace)
+      : this(
+          message: _incorrectFormat,
+          stackTrace: stackTrace,
+        );
+}

--- a/lib/domain/exceptions/git_repository_exception.dart
+++ b/lib/domain/exceptions/git_repository_exception.dart
@@ -12,7 +12,7 @@ class GitRepositoryException {
 
   /// リクエストに問題があったときの対応以来メッセージ
   static const _incorrectFormat =
-      'Data not accepted due to incorrect data format.  Try again, and if not, contact the administrator.';
+      'Data not accepted due to incorrect data format.  Try again, and if not, contact the administrator. ';
 
   const GitRepositoryException({
     this.exception,
@@ -39,7 +39,7 @@ class GitRepositoryException {
         );
 
   /// データフォーマットによる例外(サーバには達したが、無効なデータが返信された場合)
-  const GitRepositoryException.ValidationFailed(StackTrace stackTrace)
+  const GitRepositoryException.ValidationFailed({StackTrace? stackTrace})
       : this(
           message: _incorrectFormat,
           stackTrace: stackTrace,

--- a/lib/infrastructures/github_repositories/dto/result.dart
+++ b/lib/infrastructures/github_repositories/dto/result.dart
@@ -14,9 +14,10 @@ class Result with _$Result {
     fieldRename: FieldRename.snake,
   )
   const factory Result({
-    required int totalCount,
-    required bool incompleteResults,
-    required List<Item> items,
+    @Default(-1) int totalCount,
+    @Default(false) bool incompleteResults,
+    @Default(<Item>[]) List<Item> items,
+    String? message,
   }) = _Result;
 
   const Result._();

--- a/lib/infrastructures/github_repositories/github_repository.dart
+++ b/lib/infrastructures/github_repositories/github_repository.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_engineer_codecheck/domain/entities/git_repository_data.dart';
+import 'package:flutter_engineer_codecheck/domain/exceptions/git_repository_exception.dart';
 import 'package:flutter_engineer_codecheck/domain/repositories/git_repository.dart';
 import 'package:get_it/get_it.dart';
 import 'package:http/http.dart' as http;
@@ -101,6 +102,9 @@ class GithubRepository implements GitRepository {
   List<GitRepositoryData> fromJson(String jsonData) {
     final map = json.decode(jsonData) as Map<String, dynamic>;
     final result = Result.fromJson(map);
+    if (result.message != null) {
+      throw GitRepositoryException.ValidationFailed();
+    }
     return result.items.map((item) => item.toGitRepositoryData()).toList();
   }
 

--- a/lib/ui/pages/search_result_page/search_result_page.dart
+++ b/lib/ui/pages/search_result_page/search_result_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_engineer_codecheck/ui/pages/search_result_page/search_re
 import 'package:flutter_engineer_codecheck/ui/widgets/templates/day_night_template.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import 'package:loading_animations/loading_animations.dart';
 
 import '../../widgets/atoms/not_found_result.dart';
@@ -53,7 +54,13 @@ class _SearchResultPageState extends ConsumerState<SearchResultPage> {
           children: [
             Expanded(
               child: _vm.getRepositoryData.when(
-                error: (error, _) => Text(error.toString()),
+                error: (error, stacktrace) {
+                  _vm
+                      .onErrorOccurred(context, error)
+                      .then((callback) => callback());
+
+                  return Container();
+                },
                 loading: LoadingRotating.square,
                 data: (data) => NotificationListener<ScrollEndNotification>(
                   onNotification: (ScrollEndNotification notification) {

--- a/lib/ui/pages/search_result_page/search_result_page_vm.dart
+++ b/lib/ui/pages/search_result_page/search_result_page_vm.dart
@@ -1,5 +1,7 @@
+import 'package:adaptive_dialog/adaptive_dialog.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_engineer_codecheck/domain/entities/git_repository_data.dart';
+import 'package:flutter_engineer_codecheck/domain/exceptions/git_repository_exception.dart';
 import 'package:flutter_engineer_codecheck/domain/string_resources.dart';
 import 'package:flutter_engineer_codecheck/ui/pages/repository_detail_page/repository_detail_page.dart';
 import 'package:flutter_engineer_codecheck/ui/pages/search_result_page/search_result_notifier.dart';
@@ -86,5 +88,20 @@ class SearchResultPageVm {
   ) {
     GoRouter.of(context)
         .push(RepositoryDetailPage.path, extra: gitRepositoryData);
+  }
+
+  /// エラーが発生した場合の処理を定義する
+  Future<Future<void> Function()> onErrorOccurred(
+      BuildContext context, Object error) async {
+    final message =
+        error is GitRepositoryException ? error.message : error.toString();
+
+    return () async {
+      return showOkAlertDialog(
+        context: context,
+        title: 'Error occurred',
+        message: message,
+      );
+    };
   }
 }

--- a/test/infrastructures/github_repositories/dto/result_error.txt
+++ b/test/infrastructures/github_repositories/dto/result_error.txt
@@ -1,0 +1,11 @@
+{
+  "message": "Validation Failed",
+  "errors": [
+    {
+      "resource": "Search",
+      "field": "q",
+      "code": "missing"
+    }
+  ],
+  "documentation_url": "https://docs.github.com/v3/search"
+}

--- a/test/infrastructures/github_repositories/github_repository_test.dart
+++ b/test/infrastructures/github_repositories/github_repository_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter_engineer_codecheck/domain/exceptions/git_repository_exception.dart';
 import 'package:flutter_engineer_codecheck/domain/repositories/git_repository.dart';
 import 'package:flutter_engineer_codecheck/infrastructures/github_repositories/github_repository.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -135,5 +136,16 @@ void main() async {
 
     final fileData = file.readAsStringSync();
     expect(fileData.replaceAll('\r', ''), result.flutter1);
+  });
+
+  test('incorrect url', () async {
+    const filePath =
+        'test/infrastructures/github_repositories/dto/result_error.txt';
+    final file = File(filePath);
+    expect(file.existsSync(), true);
+
+    final repository = GithubRepository();
+    expect(() => repository.fromJson(file.readAsStringSync()),
+        throwsA(isInstanceOf<GitRepositoryException>()));
   });
 }


### PR DESCRIPTION
エラー処理を追加した
・Githubの通信エラー時のエラーダイアログを追加
・通信エラー時に例外を作成するので、ユーザ対応を記載した例外に置き換え
・Githubへのアクセスが不正だったときの返信に対する例外を作成
