### PR TITLE
ページを戻っても、太陽と月がきちんと表示されるようになった

### DIFF
--- a/lib/ui/widgets/templates/day_night_template.dart
+++ b/lib/ui/widgets/templates/day_night_template.dart
@@ -52,18 +52,16 @@ class DayNightTemplate extends StatelessWidget {
                   child: Semantics(
                     container: true,
                     label: AppLocalizations.of(context).swapTheme,
-                    child: Consumer(builder: (_, WidgetRef ref, __) {
-                      return SunAndMoonCoin(
-                        initStatus:
-                            ref.read(app_theme.themeMode) == ThemeMode.light
-                                ? CoinStatus.sun
-                                : CoinStatus.moon,
-                        // パディングを増やすと、SVGの大きさが小さくなるっぽい
-                        size: 48 + paddingSize * 2,
-                        callback: (CoinStatus status) =>
-                            changeTheme(ref, status),
-                      );
-                    }),
+                    child: Consumer(
+                      builder: (_, WidgetRef ref, __) {
+                        return SunAndMoonCoin(
+                          // パディングを増やすと、SVGの大きさが小さくなるっぽい
+                          size: 48 + paddingSize * 2,
+                          callback: (CoinStatus status) =>
+                              changeTheme(ref, status),
+                        );
+                      },
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
・現在のテーマをSunAndMoonCoinで持つのではなく、RiverpodのStateProviderのみで管理するように変更した ・forwardでアニメーションする最中が表示されるので、fromで最後まで飛ばすようにした